### PR TITLE
fix: update country field description in website scraper response

### DIFF
--- a/lib/services/website-scraper.ts
+++ b/lib/services/website-scraper.ts
@@ -274,7 +274,7 @@ Return ONLY valid JSON with this exact structure:
 {
   "projectName": "Project name or null",
   "category": "Category name or null",
-  "country": "Country name or null",
+  "country": "Country 2-letter ISO code or null",
   "shortDescription": "Brief description under 200 characters or null",
   "foundedAt": "YYYY or YYYY-MM-DD or null",
   "keyFeatures": ["feature1", "feature2", "feature3"],


### PR DESCRIPTION
- Changed the description of the "country" field in the JSON response to specify it should be a 2-letter ISO code or null, enhancing clarity for users of the API.