### PR TITLE
feat: add visibility fields to Project and User tables

### DIFF
--- a/prisma/migrations/20260102235443_add_visibility_fields/migration.sql
+++ b/prisma/migrations/20260102235443_add_visibility_fields/migration.sql
@@ -1,0 +1,11 @@
+-- CreateEnum
+CREATE TYPE "VisibilityMode" AS ENUM ('PUBLIC', 'GHOST', 'PRIVATE');
+
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "showMrr" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "showRevenue" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "showStats" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "visibility" "VisibilityMode" NOT NULL DEFAULT 'PUBLIC';
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "visibility" "VisibilityMode" NOT NULL DEFAULT 'PUBLIC';


### PR DESCRIPTION
- Created a new enum type `VisibilityMode` with options for visibility settings.
- Added `showMrr`, `showRevenue`, and `showStats` boolean fields to the Project table, all defaulting to true.
- Introduced a `visibility` field to both the Project and User tables, defaulting to PUBLIC.